### PR TITLE
Fix: Recipe Image Fallback in RecipeCard.jsx (closes #195)

### DIFF
--- a/frontend/src/components/RecipeCard.jsx
+++ b/frontend/src/components/RecipeCard.jsx
@@ -28,8 +28,12 @@ const RecipeCard = ({ recipe, searchQuery }) => {
     >
       <img 
         src={recipe.image} 
-        onError={(e) => { e.target.src = '/default.jpg' }} 
-        alt={recipe.name} 
+        onError={(e) => {
+        if (e.target.src !== '/default.jpg') {
+        e.target.src = '/default.jpg';
+        e.target.alt = 'Recipe image not available';
+       }
+      }}
         className="h-48 w-full object-cover" 
       />
       <div className="p-4 !bg-white dark:!bg-slate-800">


### PR DESCRIPTION
This PR fixes an issue where recipe images fail to load (due to missing or invalid image URLs) and break the UI layout.

Added a fallback mechanism in the <img> tag using onError.

If the recipe image fails to load, it now displays /default.jpg with alt text: "Recipe image not available".

--Changes Made

Updated image rendering logic with onError handler:
onError={(e) => { 
  if (e.target.src !== '/default.jpg') { 
    e.target.src = '/default.jpg'; 
    e.target.alt = 'Recipe image not available'; 
  } 
}}
