### PR TITLE
Make "Create Account" step clickable to navigate to /register

### DIFF
--- a/frontend/src/components/HowItWorksSection.jsx
+++ b/frontend/src/components/HowItWorksSection.jsx
@@ -28,18 +28,20 @@ const steps = [
 
 const StepCard = ({ step, index, isActive, onHover }) => {
   const IconComponent = step.icon;
-
+    const navigate = useNavigate(); // added this
   return (
     <div
-      className={`group relative p-8 rounded-2xl transition-all duration-700 transform hover:-translate-y-4 cursor-pointer ${
-        isActive
-          ? 'bg-gray-100 dark:!bg-gray-200 shadow-2xl scale-105 border border-gray-300 dark:border-gray-400'
-          : 'bg-white/50 dark:bg-slate-800/50 shadow-lg hover:shadow-xl'
-      }`}
-      onMouseEnter={() => onHover(index)}
-      onMouseLeave={() => onHover(-1)}
-      style={{ animationDelay: `${index * 200}ms` }}
-    >
+  className={`group relative p-8 rounded-2xl transition-all duration-700 transform hover:-translate-y-4 ${
+    isActive
+      ? 'bg-gray-100 dark:!bg-gray-200 shadow-2xl scale-105 border border-gray-300 dark:border-gray-400'
+      : 'bg-white/50 dark:bg-slate-800/50 shadow-lg hover:shadow-xl'
+  } ${index === 0 ? 'cursor-pointer' : ''}`}
+  onMouseEnter={() => onHover(index)}
+  onMouseLeave={() => onHover(-1)}
+  onClick={index === 0 ? () => navigate('/register') : undefined}
+  style={{ animationDelay: `${index * 200}ms` }}
+>
+
       {/* Step Number */}
       <div className="absolute -top-4 -left-4 w-12 h-12  dark:bg-gradient-to-r from-gray-800 to-gray-700 bg-white dark:from-white dark:to-gray-200 rounded-full flex items-center justify-center border-4 border-white dark:border-slate-900 shadow-lg">
         <span className="text-black dark:text-gray-800 font-bold text-lg">{index + 1}</span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "RECIPEDIA",
+  "name": "RECIPEDIA_Akanksha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {}


### PR DESCRIPTION
### What this PR does:
- Added click functionality to the first step card ("Create Account") in the How It Works section.
- Clicking anywhere on the card now navigates the user to the /register page, similar to the "Get Started Free" button.

### Why:
- Improves user experience by making the entire card a call-to-action.
- Keeps the behavior consistent with the bottom CTA button.

