### PR TITLE
Added Recipedia logo next to the brand text in the header

### DIFF
--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -15,6 +15,7 @@ import {
 } from "react-icons/fa";
 import { IoSunnySharp } from "react-icons/io5";
 import { authService } from '../services/authService';
+import recipediaLogo from '../../Recipedia logo.png';
 
 // ThemeToggle extracted
 const ThemeToggle = ({ theme, toggleTheme }) => (
@@ -129,9 +130,10 @@ const Navbar = ({ isAuthenticated,isLoggedIn, setIsLoggedIn,onLogout}) => {
           {/* Logo */}
           <Link
             to="/"
-            className="text-3xl font-bold text-red-500 hover:text-red-600 transition-colors duration-300"
+            className="flex items-center gap-2 text-3xl font-bold text-red-500 hover:text-red-600 transition-colors duration-300"
           >
-            Recipedia
+            <img src={recipediaLogo} alt="Recipedia logo" className="h-8 w-8 rounded-sm" />
+            <span>Recipedia</span>
           </Link>
 
           {/* Desktop Navigation Links */}


### PR DESCRIPTION
## 📌 Pull Request

### 🔗 Related Issue
Fixes #339  (if applicable)

### ✨ Description
Adds the Recipedia logo to the site header next to the “Recipedia” brand text.
Imported Recipedia logo.png and displayed it alongside the brand name
Kept existing typography, spacing, and hover styles
Ensured accessibility with alt="Recipedia logo"
Works across light/dark themes and desktop/mobile views
Updated files:
frontend/src/components/Header.jsx (import + header link markup)
frontend/Recipedia logo.png (added asset)

### 🛠️ Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor/Improvement

### ✅ Checklist
- [x] My code follows the project’s coding guidelines
- [x] I have added tests that prove my fix is effective (if applicable)
- [x] I have updated the documentation accordingly
- [x] I have linked the related issue (if applicable)

### 📸 Screenshots (if relevant)

#### Before:

<img width="1697" height="83" alt="Screenshot 2025-09-30 180031" src="https://github.com/user-attachments/assets/cabb5fd7-b06d-4704-8b6e-fce0ae224b38" />


#### After :

<img width="1730" height="224" alt="image" src="https://github.com/user-attachments/assets/2bd327dd-ab9a-4d3b-b48a-c94fa9f60306" />


---

**Note for reviewers:**  
Please provide feedback and suggestions so this PR can be improved before merging 🚀
